### PR TITLE
CP-26: Create PUT API endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@
 
 # lambda archive file
 *lambda_get_handler.zip
+*lambda_put_handler.zip

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Current Stack:
 - <b>Route53</b> to manage DNS records
 - <b>ACM</b> to create and manage SSL certs.
 - <b> API Gateway </b> used to serve view counts for my profile
-- <b> Lambda </b> used as a handler for the API responses.
+- <b> Lambda </b> used as handlers for the API responses.
 - <b> DynamoDB </b> to manage site statistics. 
 - All infrastructure is managed by <b>Terraform</b>
 

--- a/backend/lambda_put_handler.py
+++ b/backend/lambda_put_handler.py
@@ -1,0 +1,10 @@
+import json
+
+def lambda_put_handler(event, context):
+    return {
+        'statusCode': 200,
+        'headers': {
+            'Content-Type': 'application/json'
+        },
+        'body': json.dumps({'message': 'hello from update lambda!'})
+    }

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -18,10 +18,11 @@ module "route53" {
 }
 
 module "lambda" {
-  source      = "./modules/lambda"
-  source_dir  = "${path.module}/../backend/"
-  output_path = "${path.module}/../backend/lambda_get_handler.zip"
-  dynamo_arn  = module.dynamo.dynamo_arn
+  source                 = "./modules/lambda"
+  source_dir             = "${path.module}/../backend/"
+  output_path_get_lambda = "${path.module}/../backend/lambda_get_handler.zip"
+  output_path_put_lambda = "${path.module}/../backend/lambda_put_handler.zip"
+  dynamo_arn             = module.dynamo.dynamo_arn
   depends_on = [
     module.dynamo.table
   ]
@@ -33,8 +34,10 @@ module "api" {
   source                 = "./modules/api"
   region                 = "us-east-1"
   account_id             = data.aws_caller_identity.current.account_id
-  lambda_get_handler     = module.lambda.function_name
-  lambda_get_handler_arn = module.lambda.function_arn
+  lambda_get_handler     = module.lambda.get_function_name
+  lambda_get_handler_arn = module.lambda.get_function_arn
+  lambda_put_handler     = module.lambda.put_function_name
+  lambda_put_handler_arn = module.lambda.put_function_arn
   depends_on = [
     module.lambda.function
   ]

--- a/infrastructure/modules/api/main.tf
+++ b/infrastructure/modules/api/main.tf
@@ -16,6 +16,13 @@ resource "aws_api_gateway_method" "get" {
   http_method   = "GET"
 }
 
+resource "aws_api_gateway_method" "put" {
+  rest_api_id   = aws_api_gateway_rest_api.api.id
+  resource_id   = aws_api_gateway_resource.rest_api_resource.id
+  authorization = "NONE"
+  http_method   = "PUT"
+}
+
 resource "aws_api_gateway_integration" "get_integration" {
   rest_api_id             = aws_api_gateway_rest_api.api.id
   resource_id             = aws_api_gateway_resource.rest_api_resource.id
@@ -25,10 +32,26 @@ resource "aws_api_gateway_integration" "get_integration" {
   uri                     = var.lambda_get_handler_arn
 }
 
+resource "aws_api_gateway_integration" "put_integration" {
+  rest_api_id             = aws_api_gateway_rest_api.api.id
+  resource_id             = aws_api_gateway_resource.rest_api_resource.id
+  http_method             = aws_api_gateway_method.put.http_method
+  integration_http_method = "POST"
+  type                    = "AWS_PROXY"
+  uri                     = var.lambda_put_handler_arn
+}
+
 resource "aws_api_gateway_method_response" "get_response_200" {
   rest_api_id = aws_api_gateway_rest_api.api.id
   resource_id = aws_api_gateway_resource.rest_api_resource.id
   http_method = aws_api_gateway_method.get.http_method
+  status_code = "200"
+}
+
+resource "aws_api_gateway_method_response" "put_response_200" {
+  rest_api_id = aws_api_gateway_rest_api.api.id
+  resource_id = aws_api_gateway_resource.rest_api_resource.id
+  http_method = aws_api_gateway_method.put.http_method
   status_code = "200"
 }
 
@@ -42,13 +65,23 @@ resource "aws_lambda_permission" "api_gw_lambda" {
   source_arn = "arn:aws:execute-api:${var.region}:${var.account_id}:${aws_api_gateway_rest_api.api.id}/*/${aws_api_gateway_method.get.http_method}${aws_api_gateway_resource.rest_api_resource.path}"
 }
 
+resource "aws_lambda_permission" "api_gw_put_lambda" {
+  statement_id  = "AllowExecutionFromAPIGateway"
+  action        = "lambda:InvokeFunction"
+  function_name = var.lambda_put_handler
+  principal     = "apigateway.amazonaws.com"
+  source_arn    = "arn:aws:execute-api:${var.region}:${var.account_id}:${aws_api_gateway_rest_api.api.id}/*/${aws_api_gateway_method.put.http_method}${aws_api_gateway_resource.rest_api_resource.path}"
+}
+
 resource "aws_api_gateway_deployment" "deployment" {
   rest_api_id = aws_api_gateway_rest_api.api.id
   triggers = {
     redeployment = sha1(jsonencode([
       aws_api_gateway_resource.rest_api_resource.id,
       aws_api_gateway_method.get.id,
+      aws_api_gateway_method.put.id,
       aws_api_gateway_integration.get_integration.id,
+      aws_api_gateway_integration.put_integration.id,
     ]))
   }
 }

--- a/infrastructure/modules/api/variables.tf
+++ b/infrastructure/modules/api/variables.tf
@@ -29,3 +29,13 @@ variable "lambda_get_handler_arn" {
   type        = string
   description = "The ARN of the API GET lambda function"
 }
+
+variable "lambda_put_handler" {
+  type        = string
+  description = "The name of the API PUT lambda function"
+}
+
+variable "lambda_put_handler_arn" {
+  type        = string
+  description = "The ARN of the API PUT lambda function"
+}

--- a/infrastructure/modules/lambda/main.tf
+++ b/infrastructure/modules/lambda/main.tf
@@ -1,7 +1,13 @@
-data "archive_file" "lambda_handler" {
+data "archive_file" "lambda_get_handler" {
   type        = "zip"
   source_dir  = var.source_dir
-  output_path = var.output_path
+  output_path = var.output_path_get_lambda
+}
+
+data "archive_file" "lambda_put_handler" {
+  type        = "zip"
+  source_dir  = var.source_dir
+  output_path = var.output_path_put_lambda
 }
 
 resource "aws_s3_bucket" "mpcloudstack_lambda_bucket" {
@@ -13,30 +19,58 @@ resource "aws_s3_bucket_acl" "bucket_acl" {
   acl    = "private"
 }
 
-resource "aws_s3_object" "lambda_handler" {
+resource "aws_s3_object" "lambda_get_handler" {
   bucket = aws_s3_bucket.mpcloudstack_lambda_bucket.id
 
   key    = "lambda_get_handler.zip"
-  source = data.archive_file.lambda_handler.output_path
-  etag   = filemd5(data.archive_file.lambda_handler.output_path)
+  source = data.archive_file.lambda_get_handler.output_path
+  etag   = filemd5(data.archive_file.lambda_get_handler.output_path)
 }
 
-resource "aws_lambda_function" "site_counter" {
-  function_name = "site_counter"
+resource "aws_s3_object" "lambda_put_handler" {
+  bucket = aws_s3_bucket.mpcloudstack_lambda_bucket.id
+
+  key    = "lambda_put_handler.zip"
+  source = data.archive_file.lambda_put_handler.output_path
+  etag   = filemd5(data.archive_file.lambda_put_handler.output_path)
+}
+
+resource "aws_lambda_function" "get_site_counter" {
+  function_name = "get_site_counter"
 
   s3_bucket = aws_s3_bucket.mpcloudstack_lambda_bucket.id
-  s3_key    = aws_s3_object.lambda_handler.key
+  s3_key    = aws_s3_object.lambda_get_handler.key
 
   runtime = "python3.9"
   handler = "lambda_get_handler.lambda_get_handler"
 
-  source_code_hash = data.archive_file.lambda_handler.output_base64sha256
+  source_code_hash = data.archive_file.lambda_get_handler.output_base64sha256
 
   role = aws_iam_role.lambda_exec.arn
 }
 
-resource "aws_cloudwatch_log_group" "site_counter_log_group" {
-  name = "/aws/lambda/${aws_lambda_function.site_counter.function_name}"
+resource "aws_lambda_function" "update_site_counter" {
+  function_name = "update_site_counter"
+
+  s3_bucket = aws_s3_bucket.mpcloudstack_lambda_bucket.id
+  s3_key    = aws_s3_object.lambda_put_handler.key
+
+  runtime = "python3.9"
+  handler = "lambda_put_handler.lambda_put_handler"
+
+  source_code_hash = data.archive_file.lambda_put_handler.output_base64sha256
+
+  role = aws_iam_role.lambda_exec.arn
+}
+
+resource "aws_cloudwatch_log_group" "get_site_counter_log_group" {
+  name = "/aws/lambda/${aws_lambda_function.get_site_counter.function_name}"
+
+  retention_in_days = 1
+}
+
+resource "aws_cloudwatch_log_group" "update_site_counter_log_group" {
+  name = "/aws/lambda/${aws_lambda_function.update_site_counter.function_name}"
 
   retention_in_days = 1
 }

--- a/infrastructure/modules/lambda/outputs.tf
+++ b/infrastructure/modules/lambda/outputs.tf
@@ -1,11 +1,23 @@
-output "function_name" {
-  description = "Name of lambda function"
+output "get_function_name" {
+  description = "Name of get lambda function"
 
-  value = aws_lambda_function.site_counter.function_name
+  value = aws_lambda_function.get_site_counter.function_name
 }
 
-output "function_arn" {
-  description = "ARN of the lambda"
+output "get_function_arn" {
+  description = "ARN of the get lambda"
 
-  value = aws_lambda_function.site_counter.invoke_arn
+  value = aws_lambda_function.get_site_counter.invoke_arn
+}
+
+output "put_function_name" {
+  description = "Name of put lambda function"
+
+  value = aws_lambda_function.update_site_counter.function_name
+}
+
+output "put_function_arn" {
+  description = "ARN of the put lambda"
+
+  value = aws_lambda_function.update_site_counter.invoke_arn
 }

--- a/infrastructure/modules/lambda/variables.tf
+++ b/infrastructure/modules/lambda/variables.tf
@@ -3,8 +3,13 @@ variable "source_dir" {
   type        = string
 }
 
-variable "output_path" {
-  description = "Path to .zip output file"
+variable "output_path_get_lambda" {
+  description = "Path to .zip output file for get lambda"
+  type        = string
+}
+
+variable "output_path_put_lambda" {
+  description = "Path to .zip output file for put lambda"
   type        = string
 }
 

--- a/infrastructure/outputs.tf
+++ b/infrastructure/outputs.tf
@@ -29,10 +29,16 @@ output "route53_domain" {
   value       = module.route53.route53_domain
 }
 
-output "lambda_name" {
-  description = "Name of the lambda function"
-  value       = module.lambda.function_name
+output "lambda_get_name" {
+  description = "Name of the lambda get function"
+  value       = module.lambda.get_function_name
 }
+
+output "lambda_put_name" {
+  description = "Name of the lambda put function"
+  value       = module.lambda.put_function_name
+}
+
 output "rest_api_url" {
   description = "URL of the API"
   value       = module.api.rest_api_url


### PR DESCRIPTION
- Update existing lambda to conform to REST naming conventions
- Create new lambda for PUT handler
- Update resources naming standards where it made sense.

Tested API Gateway to verify both endpoints GET | PUT were returning 200s with the appropriate response body. 